### PR TITLE
Changed {{}} to -{}- to avoid popular collision

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,11 +55,11 @@ Sentencer.prototype.make = function(template) {
   var self = this;
 
   var sentence = template;
-  var occurrences = template.match(/\{\{(.+?)\}\}/g);
+  var occurrences = template.match(/-\{(.+?)\}-/g);
 
   if(occurrences && occurrences.length) {
     for(var i = 0; i < occurrences.length; i++) {
-      var action = occurrences[i].replace('{{', '').replace('}}', '').trim();
+      var action = occurrences[i].replace('-{', '').replace('}-', '').trim();
       var result = '';
       if(action.match(/\((.+?)\)/)) {
         try {


### PR DESCRIPTION
Vue.js and other popular libraries like handlebars use `{{}}`, so I converted it to `-{}-` to avoid errors that emerged from collision