### PR TITLE
Allow recursive variable expansion

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,30 +51,33 @@ function Sentencer() {
 //                  THE GOODS
 // ---------------------------------------------
 
-Sentencer.prototype.make = function(template) {
+Sentencer.prototype.make = function(template, maxIterations = 1) {
   var self = this;
 
   var sentence = template;
-  var occurrences = template.match(/\{\{(.+?)\}\}/g);
-
-  if(occurrences && occurrences.length) {
-    for(var i = 0; i < occurrences.length; i++) {
-      var action = occurrences[i].replace('{{', '').replace('}}', '').trim();
-      var result = '';
-      if(action.match(/\((.+?)\)/)) {
-        try {
-          result = eval('self.actions.' + action);
-        }
-        catch(e) { }
-      } else {
-        if(self.actions[action]) {
-          result = self.actions[action]();
+  for(var j = 0; j < maxIterations; j++) {
+    var occurrences = sentence.match(/\{\{(.+?)\}\}/g);
+  
+    if(occurrences && occurrences.length) {
+      for(var i = 0; i < occurrences.length; i++) {
+        var action = occurrences[i].replace('{{', '').replace('}}', '').trim();
+        var result = '';
+        if(action.match(/\((.+?)\)/)) {
+          try {
+            result = eval('self.actions.' + action);
+          }
+          catch(e) { }
         } else {
-          result = '{{ ' + action + ' }}';
+          if(self.actions[action]) {
+            result = self.actions[action]();
+          } else {
+            result = '{{ ' + action + ' }}';
+          }
         }
+        sentence = sentence.replace(occurrences[i], result);
       }
-      sentence = sentence.replace(occurrences[i], result);
     }
+    else break;
   }
   return sentence;
 };

--- a/tests/main.js
+++ b/tests/main.js
@@ -122,8 +122,35 @@ describe('Sentencer:', function() {
 
     });
 
+    describe('# Recursive variable expansion', function() {
+
+      Sentencer.configure({
+        actions: {
+          recurse1: function() {
+            return "recurse1 ({{ recurse2 }})";
+          },
+          recurse2: function() {
+            return "recurse2 ({{ recurse3 }})";
+          },
+          recurse3: function() {
+            return "hello world";
+          }
+        }
+      });
+
+      it('should not contain variables with sufficient depth', function() {
+        assert.equal( Sentencer.make('{{ recurse1 }}',3), 'recurse1 (recurse2 (hello world))' );
+      });
+
+      it('should contain variables if depth is insufficient', function() {
+        assert.equal( Sentencer.make('{{ recurse1 }}',2), 'recurse1 (recurse2 ({{ recurse3 }}))' );
+      });
+
+    });
+
   });
 
+  
   describe('Test Print', function() {
 
     it('should have logged a sentence', function() {


### PR DESCRIPTION
This change allows recursive variable expansion.  

For example: we can choose from a list of questions:
```javascript
var Sentencer = require('sentencer');
var randy = require('randy');

var questions = ["what is {{ a_noun }}", "why is {{ a_noun }} so {{ adjective }}"];

Sentencer.configure({
  actions: {
    question: function() {
      return randy.choice(questions);
    }
  }
});

console.log( Sentencer.make("Question 1: {{ question }}");
```